### PR TITLE
fix(dotcom-shell): update knob prop name

### DIFF
--- a/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
+++ b/packages/web-components/src/components/dotcom-shell/__stories__/dotcom-shell.stories.ts
@@ -782,7 +782,7 @@ export const withL1 = ({ parameters }) => {
 withL1.story = {
   parameters: {
     knobs: {
-      MastheadComposite: ({ groupId }) => ({
+      DotcomShell: ({ groupId }) => ({
         platform: l1PlatformData,
         hasProfile: boolean('show the profile functionality (has-profile)', true, groupId),
         hasSearch: boolean('show the search functionality (has-search)', true, groupId),


### PR DESCRIPTION
### Description

Fixes a mis-matched knob name in the `L1` story which is causing this issue which was caused by 094b1fc34fa867e38f1995adbaa098f867a175a0

![image](https://user-images.githubusercontent.com/909118/116435474-6362cc00-a819-11eb-8c25-7a78d530457e.png)


### Changelog

**Changed**

- `MastheadComposite` to `DotcomShell` in `L1` story

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
